### PR TITLE
Revive keyword option, and test programs.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,5 @@ jobs:
         run: npm install
       - name: Build
         run: npm run build
+      - name: Test
+        run: npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/schema",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "JSON and LLM function calling schemas extended for Wrtn Studio Pro",
   "main": "lib/index.js",
   "module": "./lib/index.mjs",
@@ -9,7 +9,9 @@
     "prepare": "ts-patch install",
     "build": "npm run build:main",
     "build:main": "rimraf lib && tsc && rollup -c",
-    "dev": "rimraf lib && tsc --watch"
+    "build:test": "rimraf bin && tsc -p test/tsconfig.json",
+    "dev": "npm run build:test -- --watch",
+    "test": "node bin/test"
   },
   "repository": {
     "type": "git",
@@ -32,15 +34,24 @@
     "@samchon/openapi": "^2.0.0"
   },
   "devDependencies": {
+    "@nestia/core": "^4.0.0",
+    "@nestia/e2e": "^0.7.0",
+    "@nestia/fetcher": "^4.0.0",
+    "@nestia/sdk": "^4.0.0",
+    "@nestjs/common": "^10.4.12",
+    "@nestjs/core": "^10.4.12",
+    "@nestjs/platform-express": "^10.4.12",
     "@rollup/plugin-terser": "^0.4.4",
     "@rollup/plugin-typescript": "^11.1.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/multer": "^1.4.12",
+    "multer": "^1.4.5-lts.1",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "rollup": "^4.22.0",
     "ts-patch": "^3.2.1",
     "typescript": "5.5.4",
-    "typescript-transform-paths": "^3.5.1",
+    "typescript-transform-paths": "^3.5.2",
     "typia": "^7.0.0"
   },
   "files": [

--- a/src/IHttpOpenAiApplication.ts
+++ b/src/IHttpOpenAiApplication.ts
@@ -69,7 +69,7 @@ import { ISwaggerOperation } from "./ISwaggerOperation";
  * @author Samchon
  */
 export interface IHttpOpenAiApplication
-  extends Omit<IHttpLlmApplication<"3.0">, "functions"> {
+  extends Omit<IHttpLlmApplication<"3.0">, "functions" | "options"> {
   /**
    * List of function metadata.
    *
@@ -86,6 +86,14 @@ export interface IHttpOpenAiApplication
    * OpenAI function call schemas are based on OpenAPI 3.0.3.
    */
   openapi: "3.0.3";
+
+  /**
+   * Options for the application.
+   *
+   * Adjusted options when composing the application through
+   * {@link HttpOpenAi.application} function.
+   */
+  options: IHttpOpenAiApplication.IOptions;
 }
 export namespace IHttpOpenAiApplication {
   /**
@@ -96,5 +104,35 @@ export namespace IHttpOpenAiApplication {
   /**
    * Options for composing the LLM application.
    */
-  export type IOptions = IHttpLlmApplication.IOptions<"3.0">;
+  export interface IOptions extends IHttpLlmApplication.IOptions<"3.0"> {
+    /**
+     * Whether the parameters are keyworded or not.
+     *
+     * If this property value is `true`, length of the
+     * {@link IHttpOpenAiApplication.IFunction.parameters} is always 1, and type of
+     * the pararameter is always {@link IOpenAiSchema.IObject} type.
+     *
+     * Otherwise, the parameters would be multiple, and the sequence of the parameters
+     * are following below rules.
+     *
+     * ```typescript
+     * // KEYWORD TRUE
+     * {
+     *   ...pathParameters,
+     *   query,
+     *   body,
+     * }
+     *
+     * // KEYWORD FALSE
+     * [
+     *   ...pathParameters,
+     *   ...(query ? [query] : []),
+     *   ...(body ? [body] : []),
+     * ]
+     * ```
+     *
+     * @default false
+     */
+    keyword: boolean;
+  }
 }

--- a/src/IHttpOpenAiFunction.ts
+++ b/src/IHttpOpenAiFunction.ts
@@ -92,11 +92,6 @@ export interface IHttpOpenAiFunction
   parameters: IOpenAiSchema[];
 
   /**
-   * The keyworded parameters.
-   */
-  keyword?: IOpenAiSchema.IParameters;
-
-  /**
    * Collection of separated parameters.
    *
    * Filled only when {@link IHttpOpenAiApplication.IOptions.separate} is configured.
@@ -121,11 +116,6 @@ export namespace IHttpOpenAiFunction {
      * Parameters that would be composed by the human.
      */
     human: ISeparatedParameter[];
-
-    /**
-     * The keyworded parameters' separation.
-     */
-    keyword?: IHttpLlmFunction.ISeparated<"3.0">;
   }
 
   /**

--- a/src/internal/HttpOpenAiFetcher.ts
+++ b/src/internal/HttpOpenAiFetcher.ts
@@ -22,6 +22,21 @@ export namespace HttpOpenAiFetcher {
     props: HttpOpenAi.IFetchProps,
   ): HttpMigration.IFetchProps => {
     const route: IHttpMigrateRoute = props.function.route();
+    if (props.application.options.keyword) {
+      const input: Record<string, any> = props.arguments[0] as Record<
+        string,
+        any
+      >;
+      return {
+        connection: props.connection,
+        route,
+        parameters: Object.fromEntries(
+          route.parameters.map((p) => [p.key, input[p.key]] as const),
+        ),
+        query: input.query,
+        body: input.body,
+      };
+    }
     const parameters: Array<unknown> = props.arguments.slice(
       0,
       route.parameters.length,

--- a/test/controllers/AppController.ts
+++ b/test/controllers/AppController.ts
@@ -1,0 +1,113 @@
+import {
+  TypedBody,
+  TypedFormData,
+  TypedParam,
+  TypedQuery,
+  TypedRoute,
+} from "@nestia/core";
+import { Controller, Query } from "@nestjs/common";
+import Multer from "multer";
+import { tags } from "typia";
+
+@Controller()
+export class AppController {
+  @TypedRoute.Get(":index/:level/:optimal/parameters")
+  public parameters(
+    @TypedParam("index")
+    index: string & tags.Format<"uri"> & tags.ContentMediaType<"text/html">,
+    @TypedParam("level") level: number,
+    @TypedParam("optimal") optimal: boolean,
+  ) {
+    return { index, level, optimal };
+  }
+
+  @TypedRoute.Get(":index/:level/:optimal/query")
+  public query(
+    @TypedParam("index")
+    index: string & tags.Format<"uri"> & tags.ContentMediaType<"text/html">,
+    @TypedParam("level") level: number,
+    @TypedParam("optimal") optimal: boolean,
+    @TypedQuery() query: IQuery,
+  ) {
+    return { index, level, optimal, query };
+  }
+
+  /**
+   * @tag body
+   * @tag post
+   */
+  @TypedRoute.Post(":index/:level/:optimal/body")
+  public body(
+    @TypedParam("index")
+    index: string & tags.Format<"uri"> & tags.ContentMediaType<"text/html">,
+    @TypedParam("level") level: number,
+    @TypedParam("optimal") optimal: boolean,
+    @TypedBody() body: IBody,
+  ) {
+    return { index, level, optimal, body };
+  }
+
+  @TypedRoute.Post(":index/:level/:optimal/query/body")
+  public query_body(
+    @TypedParam("index")
+    index: string & tags.Format<"uri"> & tags.ContentMediaType<"text/html">,
+    @TypedParam("level") level: number,
+    @TypedParam("optimal") optimal: boolean,
+    @Query("thumbnail")
+    thumbnail: string & tags.Format<"uri"> & tags.ContentMediaType<"image/*">,
+    @TypedQuery() query: { summary: string },
+    @TypedBody() body: IBody,
+  ) {
+    return {
+      index,
+      level,
+      optimal,
+      query: {
+        ...query,
+        thumbnail,
+      },
+      body,
+    };
+  }
+
+  @TypedRoute.Post(":index/:level/:optimal/multipart")
+  public query_multipart(
+    @TypedParam("index")
+    index: string & tags.Format<"uri"> & tags.ContentMediaType<"text/html">,
+    @TypedParam("level") level: number,
+    @TypedParam("optimal") optimal: boolean,
+    @TypedQuery() query: IQuery,
+    @TypedFormData.Body(() => Multer())
+    body: IMultipart,
+  ) {
+    return {
+      index,
+      level,
+      optimal,
+      query,
+      body: {
+        ...body,
+        file: `http://localhost:3000/files/${Date.now()}.raw`,
+      },
+    };
+  }
+
+  /**
+   * @deprecated
+   */
+  @TypedRoute.Get("nothing")
+  public nothing(): void {}
+}
+
+interface IQuery {
+  summary: string;
+  thumbnail: string & tags.Format<"uri"> & tags.ContentMediaType<"image/*">;
+}
+interface IBody {
+  title: string;
+  body: string;
+  draft: boolean;
+}
+interface IMultipart extends IBody {
+  file: File;
+}

--- a/test/controllers/AppFilter.ts
+++ b/test/controllers/AppFilter.ts
@@ -1,0 +1,12 @@
+import { ArgumentsHost, Catch, HttpException } from "@nestjs/common";
+import { BaseExceptionFilter } from "@nestjs/core";
+
+@Catch()
+export class AppFilter extends BaseExceptionFilter {
+  public async catch(exception: HttpException | Error, host: ArgumentsHost) {
+    const status: number =
+      exception instanceof HttpException ? exception.getStatus() : 500;
+    if (status === 500) console.info(exception);
+    return super.catch(exception, host);
+  }
+}

--- a/test/controllers/AppModule.ts
+++ b/test/controllers/AppModule.ts
@@ -1,0 +1,8 @@
+import { Module } from "@nestjs/common";
+
+import { AppController } from "./AppController";
+
+@Module({
+  controllers: [AppController],
+})
+export class AppModule {}

--- a/test/features/test_http_llm_application_keyword.ts
+++ b/test/features/test_http_llm_application_keyword.ts
@@ -1,0 +1,34 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpMigrateRoute, ILlmSchema, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_application_keyword = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+    },
+  });
+  for (const func of application.functions) {
+    const route: IHttpMigrateRoute = func.route();
+    TestValidator.equals("length")(1)(func.parameters.length);
+    TestValidator.equals("properties")([
+      ...route.parameters.map((p) => p.key),
+      ...(route.query ? ["query"] : []),
+      ...(route.body ? ["body"] : []),
+    ])(
+      (() => {
+        const schema: ILlmSchema = func.parameters[0];
+        if (!OpenAiTypeChecker.isObject(schema)) return [];
+        return Object.keys(schema.properties ?? {});
+      })(),
+    );
+  }
+};

--- a/test/features/test_http_llm_application_positional.ts
+++ b/test/features/test_http_llm_application_positional.ts
@@ -1,0 +1,21 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpMigrateRoute, OpenApi } from "@samchon/openapi";
+import { HttpOpenAi, IHttpOpenAiApplication } from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_application_positional = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: false,
+    },
+  });
+  for (const func of application.functions) {
+    const route: IHttpMigrateRoute = func.route();
+    TestValidator.equals("length")(func.parameters.length)(
+      route.parameters.length + (route.query ? 1 : 0) + (route.body ? 1 : 0),
+    );
+  }
+};

--- a/test/features/test_http_llm_fetcher_keyword_body.ts
+++ b/test/features/test_http_llm_fetcher_keyword_body.ts
@@ -1,0 +1,54 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_body = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) => f.path === "/{index}/{level}/{optimal}/body" && f.method === "post",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        {
+          level: 123,
+          optimal: true,
+          body: {
+            title: "some title",
+            body: "some body",
+            draft: false,
+          },
+        },
+      ],
+      human: [
+        {
+          index: "https://some.url/index.html",
+        },
+      ],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(201);
+};

--- a/test/features/test_http_llm_fetcher_keyword_parameters.ts
+++ b/test/features/test_http_llm_fetcher_keyword_parameters.ts
@@ -1,0 +1,50 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_parameters = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) =>
+      f.path === "/{index}/{level}/{optimal}/parameters" && f.method === "get",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        {
+          level: 123,
+          optimal: true,
+        },
+      ],
+      human: [
+        {
+          index: "https://some.url/index.html",
+        },
+      ],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(200);
+};

--- a/test/features/test_http_llm_fetcher_keyword_query.ts
+++ b/test/features/test_http_llm_fetcher_keyword_query.ts
@@ -1,0 +1,55 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_query = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) => f.path === "/{index}/{level}/{optimal}/query" && f.method === "get",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        {
+          level: 123,
+          optimal: true,
+          query: {
+            summary: "some summary",
+          },
+        },
+      ],
+      human: [
+        {
+          index: "https://some.url/index.html",
+          query: {
+            thumbnail: "https://some.url/file.jpg",
+          },
+        },
+      ],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(200);
+};

--- a/test/features/test_http_llm_fetcher_keyword_query_and_body.ts
+++ b/test/features/test_http_llm_fetcher_keyword_query_and_body.ts
@@ -1,0 +1,61 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_query_and_body = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) =>
+      f.path === "/{index}/{level}/{optimal}/query/body" && f.method === "post",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        {
+          level: 123,
+          optimal: true,
+          query: {
+            summary: "some summary",
+          },
+          body: {
+            title: "some title",
+            body: "some body",
+            draft: false,
+          },
+        },
+      ],
+      human: [
+        {
+          index: "https://some.url/index.html",
+          query: {
+            thumbnail: "https://some.url/file.jpg",
+          },
+        },
+      ],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(201);
+};

--- a/test/features/test_http_llm_fetcher_positional_body.ts
+++ b/test/features/test_http_llm_fetcher_positional_body.ts
@@ -1,0 +1,48 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_positional_body = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: false,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) => f.path === "/{index}/{level}/{optimal}/body" && f.method === "post",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        123,
+        true,
+        {
+          title: "some title",
+          body: "some body",
+          draft: false,
+        },
+      ],
+      human: ["https://some.url/index.html"],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(201);
+};

--- a/test/features/test_http_llm_fetcher_positional_parameters.ts
+++ b/test/features/test_http_llm_fetcher_positional_parameters.ts
@@ -1,0 +1,41 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_parameters = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: false,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) =>
+      f.path === "/{index}/{level}/{optimal}/parameters" && f.method === "get",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [123, true],
+      human: ["https://some.url/index.html"],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(200);
+};

--- a/test/features/test_http_llm_fetcher_positional_query.ts
+++ b/test/features/test_http_llm_fetcher_positional_query.ts
@@ -1,0 +1,51 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_query = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: false,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) => f.path === "/{index}/{level}/{optimal}/query" && f.method === "get",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        123,
+        true,
+        {
+          summary: "some summary",
+        },
+      ],
+      human: [
+        "https://some.url/index.html",
+        {
+          thumbnail: "https://some.url/file.jpg",
+        },
+      ],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(200);
+};

--- a/test/features/test_http_llm_fetcher_positional_query_and_body.ts
+++ b/test/features/test_http_llm_fetcher_positional_query_and_body.ts
@@ -1,0 +1,57 @@
+import { TestValidator } from "@nestia/e2e";
+import { IHttpConnection, IHttpResponse, OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_fetcher_keyword_query_and_body = async (
+  connection: IHttpConnection,
+): Promise<void> => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: false,
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) && !!schema.contentMediaType,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) =>
+      f.path === "/{index}/{level}/{optimal}/query/body" && f.method === "post",
+  );
+  if (func === undefined) throw new Error("Function not found");
+
+  const response: IHttpResponse = await HttpOpenAi.propagate({
+    connection,
+    application,
+    function: func,
+    arguments: HttpOpenAi.mergeParameters({
+      function: func,
+      llm: [
+        123,
+        true,
+        {
+          summary: "some summary",
+        },
+        {
+          title: "some title",
+          body: "some body",
+          draft: false,
+        },
+      ],
+      human: [
+        "https://some.url/index.html",
+        {
+          thumbnail: "https://some.url/file.jpg",
+        },
+      ],
+    }),
+  });
+  TestValidator.equals("response.status")(response.status)(201);
+};

--- a/test/features/test_http_llm_function_deprecated.ts
+++ b/test/features/test_http_llm_function_deprecated.ts
@@ -1,0 +1,23 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_function_deprecated = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) => f.method === "get" && f.path === "/nothing",
+  );
+  TestValidator.equals("deprecated")(func?.deprecated)(true);
+};

--- a/test/features/test_http_llm_function_multipart.ts
+++ b/test/features/test_http_llm_function_multipart.ts
@@ -1,0 +1,22 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@samchon/openapi";
+import { HttpOpenAi, IHttpOpenAiApplication } from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_function_multipart = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+    },
+  });
+  TestValidator.equals("multipart not suppported")(
+    !!application.errors.find(
+      (e) =>
+        e.method === "post" &&
+        e.path === "/{index}/{level}/{optimal}/multipart",
+    ),
+  )(true);
+};

--- a/test/features/test_http_llm_function_tags.ts
+++ b/test/features/test_http_llm_function_tags.ts
@@ -1,0 +1,23 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+} from "@wrtnio/schema";
+
+import swagger from "../swagger.json";
+
+export const test_http_llm_function_deprecated = (): void => {
+  const document: OpenApi.IDocument = OpenApi.convert(swagger as any);
+  const application: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      keyword: true,
+    },
+  });
+  const func: IHttpOpenAiFunction | undefined = application.functions.find(
+    (f) => f.method === "post" && f.path === "/{index}/{level}/{optimal}/body",
+  );
+  TestValidator.equals("tags")(func?.tags)(["body", "post"]);
+};

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,67 @@
+import { DynamicExecutor } from "@nestia/e2e";
+import { NestFactory } from "@nestjs/core";
+import chalk from "chalk";
+
+import { AppFilter } from "./controllers/AppFilter";
+import { AppModule } from "./controllers/AppModule";
+
+const EXTENSION = __filename.substr(-2);
+if (EXTENSION === "js") require("source-map-support").install();
+
+const getArguments = (type: string): string[] => {
+  const from: number = process.argv.indexOf(`--${type}`) + 1;
+  if (from === 0) return [];
+  const to: number = process.argv
+    .slice(from)
+    .findIndex((str) => str.startsWith("--"), from);
+  return process.argv.slice(from, to === -1 ? process.argv.length : to + from);
+};
+
+const main = async (): Promise<void> => {
+  // PREPARE SERVER
+  const app = await NestFactory.create(AppModule, { logger: false });
+  app.useGlobalFilters(new AppFilter(app.getHttpAdapter()));
+  await app.listen(3_000);
+
+  // DO TEST
+  const include: string[] = getArguments("include");
+  const exclude: string[] = getArguments("exclude");
+  const report: DynamicExecutor.IReport = await DynamicExecutor.validate({
+    prefix: "test_",
+    location: __dirname + "/features",
+    parameters: () => [
+      {
+        host: `http://localhost:3000`,
+      },
+    ],
+    onComplete: (exec) => {
+      const trace = (str: string) =>
+        console.log(`  - ${chalk.green(exec.name)}: ${str}`);
+      if (exec.error === null) {
+        const elapsed: number =
+          new Date(exec.completed_at).getTime() -
+          new Date(exec.started_at).getTime();
+        trace(`${chalk.yellow(elapsed.toLocaleString())} ms`);
+      } else trace(chalk.red(exec.error.name));
+    },
+    filter: (name) =>
+      (include.length ? include.some((str) => name.includes(str)) : true) &&
+      (exclude.length ? exclude.every((str) => !name.includes(str)) : true),
+  });
+
+  // REPORT EXCEPTIONS
+  const exceptions: Error[] = report.executions
+    .filter((exec) => exec.error !== null)
+    .map((exec) => exec.error!);
+  if (exceptions.length === 0) {
+    console.log("Success");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  } else {
+    for (const exp of exceptions) console.log(exp);
+    console.log("Failed");
+    console.log("Elapsed time", report.time.toLocaleString(), `ms`);
+  }
+  await app.close();
+  if (exceptions.length) process.exit(-1);
+};
+main().catch(console.error);

--- a/test/nestia.config.ts
+++ b/test/nestia.config.ts
@@ -1,0 +1,13 @@
+import { INestiaConfig } from "@nestia/sdk";
+import { NestFactory } from "@nestjs/core";
+
+import { AppModule } from "./controllers/AppModule";
+
+export const NESTIA_CONFIG: INestiaConfig = {
+  input: () => NestFactory.create(AppModule),
+  swagger: {
+    output: "./swagger.json",
+    beautify: true,
+  },
+};
+export default NESTIA_CONFIG;

--- a/test/swagger.json
+++ b/test/swagger.json
@@ -1,0 +1,567 @@
+{
+  "openapi": "3.1.0",
+  "servers": [
+    {
+      "url": "https://github.com/samchon/nestia",
+      "description": "insert your server url"
+    }
+  ],
+  "info": {
+    "version": "1.2.0",
+    "title": "@samchon/openapi",
+    "description": "OpenAPI definitions and converters for 'typia' and 'nestia'.",
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "paths": {
+    "/{index}/{level}/{optimal}/parameters": {
+      "get": {
+        "tags": [],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "text/html"
+            },
+            "required": true
+          },
+          {
+            "name": "level",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "required": true
+          },
+          {
+            "name": "optimal",
+            "in": "path",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{index}/{level}/{optimal}/query": {
+      "get": {
+        "tags": [],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "text/html"
+            },
+            "required": true
+          },
+          {
+            "name": "level",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "required": true
+          },
+          {
+            "name": "optimal",
+            "in": "path",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": true
+          },
+          {
+            "name": "summary",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "thumbnail",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "image/*"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "$ref": "#/components/schemas/IQuery"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "query"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{index}/{level}/{optimal}/body": {
+      "post": {
+        "tags": [
+          "body",
+          "post"
+        ],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "text/html"
+            },
+            "required": true
+          },
+          {
+            "name": "level",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "required": true
+          },
+          {
+            "name": "optimal",
+            "in": "path",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "body": {
+                      "$ref": "#/components/schemas/IBody"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "body"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{index}/{level}/{optimal}/query/body": {
+      "post": {
+        "tags": [],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "text/html"
+            },
+            "required": true
+          },
+          {
+            "name": "level",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "required": true
+          },
+          {
+            "name": "optimal",
+            "in": "path",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": true
+          },
+          {
+            "name": "thumbnail",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "image/*"
+            },
+            "required": true
+          },
+          {
+            "name": "summary",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "type": "object",
+                      "properties": {
+                        "thumbnail": {
+                          "type": "string",
+                          "format": "uri",
+                          "contentMediaType": "image/*"
+                        },
+                        "summary": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "thumbnail",
+                        "summary"
+                      ]
+                    },
+                    "body": {
+                      "$ref": "#/components/schemas/IBody"
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "query",
+                    "body"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{index}/{level}/{optimal}/multipart": {
+      "post": {
+        "tags": [],
+        "parameters": [
+          {
+            "name": "index",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "text/html"
+            },
+            "required": true
+          },
+          {
+            "name": "level",
+            "in": "path",
+            "schema": {
+              "type": "number"
+            },
+            "required": true
+          },
+          {
+            "name": "optimal",
+            "in": "path",
+            "schema": {
+              "type": "boolean"
+            },
+            "required": true
+          },
+          {
+            "name": "summary",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "thumbnail",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uri",
+              "contentMediaType": "image/*"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/IMultipart"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "index": {
+                      "type": "string",
+                      "format": "uri",
+                      "contentMediaType": "text/html"
+                    },
+                    "level": {
+                      "type": "number"
+                    },
+                    "optimal": {
+                      "type": "boolean"
+                    },
+                    "query": {
+                      "$ref": "#/components/schemas/IQuery"
+                    },
+                    "body": {
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "type": "string"
+                        },
+                        "title": {
+                          "type": "string"
+                        },
+                        "body": {
+                          "type": "string"
+                        },
+                        "draft": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "file",
+                        "title",
+                        "body",
+                        "draft"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "index",
+                    "level",
+                    "optimal",
+                    "query",
+                    "body"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nothing": {
+      "get": {
+        "deprecated": true,
+        "tags": [],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {}
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IQuery": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "type": "string"
+          },
+          "thumbnail": {
+            "type": "string",
+            "format": "uri",
+            "contentMediaType": "image/*"
+          }
+        },
+        "required": [
+          "summary",
+          "thumbnail"
+        ]
+      },
+      "IBody": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "title",
+          "body",
+          "draft"
+        ]
+      },
+      "IMultipart": {
+        "type": "object",
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary"
+          },
+          "title": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "draft": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "file",
+          "title",
+          "body",
+          "draft"
+        ]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "body"
+    },
+    {
+      "name": "post"
+    }
+  ],
+  "x-samchon-emended": true
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "outDir": "../bin",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "resolveJsonModule": true,
+    "paths": {
+      "@wrtnio/schema": ["../src/index.ts"],
+      "@wrtnio/schema/lib/*": ["../src/*"],
+    },
+    "plugins": [
+      { "transform": "typescript-transform-paths" },
+      { "transform": "typia/lib/transform" },
+      { "transform": "@nestia/core/lib/transform" },
+    ]
+  },
+  "include": ["../src", "../test"]
+}


### PR DESCRIPTION
This pull request includes several updates to the `@wrtnio/schema` package, focusing on version updates, new development dependencies, and enhancements to the `HttpOpenAi` namespace and related interfaces. Additionally, new test cases and controllers were added to support these changes.

### Version and Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version to `2.0.2` and added several new development dependencies, including `@nestia/core`, `@nestia/e2e`, `@nestia/fetcher`, `@nestia/sdk`, and `@nestjs` packages. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R37-R54)

### Enhancements to `HttpOpenAi`:
* [`src/HttpOpenAi.ts`](diffhunk://#diff-b1e21df3d662d58baaf21ae7e4c2089d92e5042b18a5953a3e964462497f6baeR19-R21): Added a `@deprecated` tag to the `HttpOpenAi` namespace and updated the `functional` method to support keyword options. [[1]](diffhunk://#diff-b1e21df3d662d58baaf21ae7e4c2089d92e5042b18a5953a3e964462497f6baeR19-R21) [[2]](diffhunk://#diff-b1e21df3d662d58baaf21ae7e4c2089d92e5042b18a5953a3e964462497f6baeL34-R43) [[3]](diffhunk://#diff-b1e21df3d662d58baaf21ae7e4c2089d92e5042b18a5953a3e964462497f6baeL52-L75)
* [`src/IHttpOpenAiApplication.ts`](diffhunk://#diff-bb57db1acd85d5e18267e1e3442eb156a852cb00ae10c4d498a9c17af091b9d3L72-R72): Extended the `IHttpOpenAiApplication` interface to include `options` for keyword parameters. [[1]](diffhunk://#diff-bb57db1acd85d5e18267e1e3442eb156a852cb00ae10c4d498a9c17af091b9d3L72-R72) [[2]](diffhunk://#diff-bb57db1acd85d5e18267e1e3442eb156a852cb00ae10c4d498a9c17af091b9d3R89-R96) [[3]](diffhunk://#diff-bb57db1acd85d5e18267e1e3442eb156a852cb00ae10c4d498a9c17af091b9d3L99-R137)
* [`src/IHttpOpenAiFunction.ts`](diffhunk://#diff-d1d2172c79247795cdd7a522ff8dd8a28464e69b8f90e1b8213b110ff6ef957fL94-L98): Removed the `keyword` property from the `IHttpOpenAiFunction` interface and its nested `separated` object. [[1]](diffhunk://#diff-d1d2172c79247795cdd7a522ff8dd8a28464e69b8f90e1b8213b110ff6ef957fL94-L98) [[2]](diffhunk://#diff-d1d2172c79247795cdd7a522ff8dd8a28464e69b8f90e1b8213b110ff6ef957fL124-L128)

### New Controllers and Modules:
* [`test/controllers/AppController.ts`](diffhunk://#diff-db6ebfb9faa3e22ab262b1198a60f74e5bf4f5046dc6e4c2913dc3d100332a37R1-R113): Added a new controller with various routes for handling parameters, queries, bodies, and multipart form data.
* [`test/controllers/AppFilter.ts`](diffhunk://#diff-cac8dd3a03dbfa9c1e19c5beb68eaf7fd1a72ffec54447c322c883f17bcc47f4R1-R12): Added a new exception filter to handle HTTP exceptions.
* [`test/controllers/AppModule.ts`](diffhunk://#diff-186e966ba059b222622daa10834e42014a9faf8c3fa48f9e36f9f6a5ebeeed8fR1-R8): Created a new module to register the `AppController`.

### New Test Cases:
* Added several new test cases to validate the functionality of the `HttpOpenAi` application and fetcher with keyword parameters:
  * `test/features/test_http_llm_application_keyword.ts`
  * `test/features/test_http_llm_application_positional.ts`
  * `test/features/test_http_llm_fetcher_keyword_body.ts`
  * `test/features/test_http_llm_fetcher_keyword_parameters.ts`
  * `test/features/test_http_llm_fetcher_keyword_query.ts`
  * `test/features/test_http_llm_fetcher_keyword_query_and_body.ts`