### PR TITLE
`x-wrtn-experimental` operation tag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/schema",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "JSON and LLM function calling schemas extended for Wrtn Studio Pro",
   "main": "lib/index.js",
   "module": "./lib/index.mjs",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/wrtnio/schema#readme",
   "dependencies": {
-    "@samchon/openapi": "^2.0.3"
+    "@samchon/openapi": "^2.0.4"
   },
   "devDependencies": {
     "@nestia/core": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/schema",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "JSON and LLM function calling schemas extended for Wrtn Studio Pro",
   "main": "lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/ISwaggerOperation.ts
+++ b/src/ISwaggerOperation.ts
@@ -22,6 +22,15 @@ declare module "@samchon/openapi" {
        * so that it can be called without any other APIs or not.
        */
       "x-wrtn-standalone"?: boolean;
+
+      /**
+       * Whether experimental or not.
+       *
+       * `x-wrtn-experimental` is a property means whether the target API is experimental
+       * so that it can be revealed in the production environment or not. In other words,
+       * if the property is `true`, the API is only available in the development environment.
+       */
+      "x-wrtn-experimental"?: boolean;
     }
   }
 }

--- a/src/internal/HttpOpenAiSeparator.ts
+++ b/src/internal/HttpOpenAiSeparator.ts
@@ -60,6 +60,12 @@ export namespace HttpOpenAiSeparator {
     (
       input: IOpenAiSchema.IObject,
     ): [IOpenAiSchema.IObject | null, IOpenAiSchema.IObject | null] => {
+      if (
+        Object.keys(input.properties ?? {}).length === 0 &&
+        !!input.additionalProperties === false
+      )
+        return [input, null];
+
       const llm = {
         ...input,
         properties: {} as Record<string, IOpenAiSchema>,
@@ -68,6 +74,7 @@ export namespace HttpOpenAiSeparator {
         ...input,
         properties: {} as Record<string, IOpenAiSchema>,
       } satisfies IOpenAiSchema.IObject;
+
       for (const [key, value] of Object.entries(input.properties ?? {})) {
         const [x, y] = schema(predicator)(value);
         if (x !== null) llm.properties[key] = x;

--- a/test/features/test_http_llm_separate_parameters_of_empty.ts
+++ b/test/features/test_http_llm_separate_parameters_of_empty.ts
@@ -1,0 +1,56 @@
+import { TestValidator } from "@nestia/e2e";
+import { OpenApi } from "@samchon/openapi";
+import {
+  HttpOpenAi,
+  IHttpOpenAiApplication,
+  IHttpOpenAiFunction,
+  OpenAiTypeChecker,
+} from "@wrtnio/schema";
+
+export const test_http_llm_separate_parameters_of_empty = (): void => {
+  const document: OpenApi.IDocument = {
+    openapi: "3.1.0",
+    "x-samchon-emended": true,
+    components: {},
+    paths: {
+      "/": {
+        post: {
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {},
+                  required: [],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  const app: IHttpOpenAiApplication = HttpOpenAi.application({
+    document,
+    options: {
+      separate: (schema) =>
+        OpenAiTypeChecker.isString(schema) &&
+        schema["x-wrtn-secret-key"] !== undefined,
+    },
+  });
+  const func: IHttpOpenAiFunction = app.functions[0];
+  TestValidator.equals("separated")(func.separated)({
+    llm: [
+      {
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+        index: 0,
+      },
+    ],
+    human: [],
+  });
+};


### PR DESCRIPTION
This pull request includes a version update and the addition of a new property to the API schema. The most important changes are as follows:

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from 3.0.1 to 3.0.2.

API schema enhancement:

* [`src/ISwaggerOperation.ts`](diffhunk://#diff-15f73630f0c66ca617b34e75169f19fa5ff28c67ae9b29ec6bf16205d08f82b6R25-R33): Added a new property `x-wrtn-experimental` to indicate whether an API is experimental and should only be available in the development environment.