### PR TITLE
Expand `ISwaggerSchema` to LLM schemas.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wrtnio/schema",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "JSON and LLM function calling schemas extended for Wrtn Studio Pro",
   "main": "lib/index.js",
   "module": "./lib/index.mjs",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/wrtnio/schema#readme",
   "dependencies": {
-    "@samchon/openapi": "^2.2.1"
+    "@samchon/openapi": "^2.3.3"
   },
   "devDependencies": {
     "@nestia/core": "^4.4.2",

--- a/src/ISwaggerSchema.ts
+++ b/src/ISwaggerSchema.ts
@@ -17,4 +17,58 @@ declare module "@samchon/openapi" {
       export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
     }
   }
+
+  export namespace IChatGptSchema {
+    export interface IInteger extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface INumber extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface IString
+      extends ISwaggerSchemaPaymentPlugin.IString,
+        ISwaggerSchemaSecurityPlugin {}
+    export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
+  }
+
+  export namespace IClaudeSchema {
+    export interface IInteger extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface INumber extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface IString
+      extends ISwaggerSchemaPaymentPlugin.IString,
+        ISwaggerSchemaSecurityPlugin {}
+    export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
+  }
+
+  export namespace IGeminiSchema {
+    export interface IInteger extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface INumber extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface IString
+      extends ISwaggerSchemaPaymentPlugin.IString,
+        ISwaggerSchemaSecurityPlugin {}
+    export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
+  }
+
+  export namespace ILlamaSchema {
+    export interface IInteger extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface INumber extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface IString
+      extends ISwaggerSchemaPaymentPlugin.IString,
+        ISwaggerSchemaSecurityPlugin {}
+    export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
+  }
+
+  export namespace ILlmSchemaV3 {
+    export interface IInteger extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface INumber extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface IString
+      extends ISwaggerSchemaPaymentPlugin.IString,
+        ISwaggerSchemaSecurityPlugin {}
+    export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
+  }
+
+  export namespace ILlmSchemaV3_1 {
+    export interface IInteger extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface INumber extends ISwaggerSchemaPaymentPlugin.INumeric {}
+    export interface IString
+      extends ISwaggerSchemaPaymentPlugin.IString,
+        ISwaggerSchemaSecurityPlugin {}
+    export interface __IAttribute extends ISwaggerSchemaCommonPlugin {}
+  }
 }


### PR DESCRIPTION
This pull request includes updates to the `package.json` file and adds new namespaces to the `src/ISwaggerSchema.ts` file to support different schema types. The most important changes are as follows:

Version and dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `3.2.0` to `3.2.1` to reflect the new changes.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L34-R34): Updated the dependency `@samchon/openapi` from version `^2.2.1` to `^2.3.3`.

Schema additions:

* [`src/ISwaggerSchema.ts`](diffhunk://#diff-a3fd90136ab68325030ddcb1f418e0c129bdea6fef9f48e7497cb52b99f59d32R20-R73): Added new namespaces `IChatGptSchema`, `IClaudeSchema`, `IGeminiSchema`, `ILlamaSchema`, `ILlmSchemaV3`, and `ILlmSchemaV3_1` with corresponding interfaces for `IInteger`, `INumber`, `IString`, and `__IAttribute`.